### PR TITLE
Implement Custom Zoom via Debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
       "http://*.google.com/"
     ],
     "permissions": [
-      "debugger",
-      "activeTab"
+      "debugger"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
     "default_locale": "en",
     "host_permissions": [
       "http://*.google.com/"
+    ],
+    "permissions": [
+      "debugger",
+      "activeTab"
     ]
   }
 }

--- a/src/background/messages/execute-enter.ts
+++ b/src/background/messages/execute-enter.ts
@@ -1,0 +1,35 @@
+import type { PlasmoMessaging } from "@plasmohq/messaging"
+
+import { setupSentry } from "../../utils/sentry-background"
+
+const sentryWrap = setupSentry("background")
+
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  sentryWrap(() => {
+    chrome.tabs.query({ active: true }).then((tabs) => {
+      const currentTab = tabs[0]
+      const target = { tabId: currentTab.id }
+
+      const key = {
+        code: "Enter",
+        key: "Enter"
+        // windowsVirtualKeyCode: 13,
+        // nativeVirtualKeyCode: 13,
+        // macCharCode: 13
+      }
+
+      chrome.debugger.attach(target, "1.0")
+      chrome.debugger.sendCommand(target, "Input.insertText", {
+        text: "125"
+      })
+      chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+        type: "keyUp",
+        ...key
+      })
+
+      chrome.debugger.detach(target)
+    })
+  })
+}
+
+export default handler

--- a/src/background/messages/execute-enter.ts
+++ b/src/background/messages/execute-enter.ts
@@ -9,36 +9,31 @@ const handler: PlasmoMessaging.MessageHandler<ExecuteEnterRequestBody> = async (
   req
 ) => {
   sentryWrap(() => {
-    // this is wrong. how do i get the tab id of the tab that is requesting this action?? match the url? needs more permissions...
-    chrome.tabs.query({ active: true }).then((tabs) => {
-      console.log(tabs)
-      const currentTab = tabs[0]
-      const target = { tabId: currentTab.id }
+    const target = { tabId: req.tabId }
 
-      chrome.debugger.attach(target, "1.0")
+    chrome.debugger.attach(target, "1.0")
 
-      chrome.debugger.sendCommand(target, "Input.insertText", {
-        text: req.body.zoomValue
-      })
-
-      // The two events below have to be used together. I don't know why... but they do...
-      chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
-        type: "rawKeyDown",
-        code: "Enter",
-        key: "Enter",
-        macCharCode: 13,
-        nativeVirtualKeyCode: 13,
-        text: "\r", //This is the critical part
-        unmodifiedText: "\r", //This is the critical part
-        windowsVirtualKeyCode: 13
-      })
-      chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
-        type: "char",
-        text: "\r"
-      })
-
-      chrome.debugger.detach(target)
+    chrome.debugger.sendCommand(target, "Input.insertText", {
+      text: req.body.zoomValue
     })
+
+    // The two events below have to be used together. I don't know why... but they do...
+    chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+      type: "rawKeyDown",
+      code: "Enter",
+      key: "Enter",
+      macCharCode: 13,
+      nativeVirtualKeyCode: 13,
+      text: "\r", //This is the critical part
+      unmodifiedText: "\r", //This is the critical part
+      windowsVirtualKeyCode: 13
+    })
+    chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+      type: "char",
+      text: "\r"
+    })
+
+    chrome.debugger.detach(target)
   })
 }
 

--- a/src/background/messages/execute-enter.ts
+++ b/src/background/messages/execute-enter.ts
@@ -1,30 +1,40 @@
 import type { PlasmoMessaging } from "@plasmohq/messaging"
 
+import type { ExecuteEnterRequestBody } from "../../types"
 import { setupSentry } from "../../utils/sentry-background"
 
 const sentryWrap = setupSentry("background")
 
-const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+const handler: PlasmoMessaging.MessageHandler<ExecuteEnterRequestBody> = async (
+  req
+) => {
   sentryWrap(() => {
+    // this is wrong. how do i get the tab id of the tab that is requesting this action?? match the url? needs more permissions...
     chrome.tabs.query({ active: true }).then((tabs) => {
+      console.log(tabs)
       const currentTab = tabs[0]
       const target = { tabId: currentTab.id }
 
-      const key = {
-        code: "Enter",
-        key: "Enter"
-        // windowsVirtualKeyCode: 13,
-        // nativeVirtualKeyCode: 13,
-        // macCharCode: 13
-      }
-
       chrome.debugger.attach(target, "1.0")
+
       chrome.debugger.sendCommand(target, "Input.insertText", {
-        text: "125"
+        text: req.body.zoomValue
+      })
+
+      // The two events below have to be used together. I don't know why... but they do...
+      chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+        type: "rawKeyDown",
+        code: "Enter",
+        key: "Enter",
+        macCharCode: 13,
+        nativeVirtualKeyCode: 13,
+        text: "\r", //This is the critical part
+        unmodifiedText: "\r", //This is the critical part
+        windowsVirtualKeyCode: 13
       })
       chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
-        type: "keyUp",
-        ...key
+        type: "char",
+        text: "\r"
       })
 
       chrome.debugger.detach(target)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const OBSERVE_EXECUTION_LIMIT = 1000
 
 // This needs to match the file name ./src/background/messages/get-zoom-value.ts
 export const RELAY_GET_ZOOM_VALUE_FROM_STORAGE = "get-zoom-value"
+export const RELAY_EXECUTE_ENTER = "execute-enter"
 
 /**  Workspace Application: Docs - Start **/
 export const DOCS_STORAGE_KEY: DocsStorageKey = "zoomValue"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,7 +49,7 @@ export const workspaceApps: WorkspaceApp[] = [
     storageKey: DOCS_STORAGE_KEY,
     isEnabled: true,
     features: {
-      customZoomInput: false
+      customZoomInput: true
     }
   },
   {
@@ -69,6 +69,7 @@ export const workspaceAppUiStrategyConfigs: Record<
 > = {
   Docs: {
     application: "Docs",
+    features: workspaceApps.find((app) => app.name === "Docs").features,
     storageKey: DOCS_STORAGE_KEY,
     uiElements: {
       clickableZoomSelectId: "#zoomSelect",
@@ -81,6 +82,7 @@ export const workspaceAppUiStrategyConfigs: Record<
   },
   Sheets: {
     application: "Sheets",
+    features: workspaceApps.find((app) => app.name === "Sheets").features,
     storageKey: SHEETS_STORAGE_KEY,
     uiElements: {
       clickableZoomSelectId: "#t-zoom",

--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -5,6 +5,7 @@ import { relayMessage } from "@plasmohq/messaging"
 
 import {
   OBSERVE_EXECUTION_LIMIT,
+  RELAY_EXECUTE_ENTER,
   RELAY_GET_ZOOM_VALUE_FROM_STORAGE,
   workspaceAppUiStrategyConfigs
 } from "../constants"
@@ -25,6 +26,7 @@ export const getStyle = () => {
 
 // create and "register" the relay
 relayMessage({ name: RELAY_GET_ZOOM_VALUE_FROM_STORAGE })
+relayMessage({ name: RELAY_EXECUTE_ENTER })
 
 const currentApp = getCurrentApp()
 let strategy

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -37,28 +37,31 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
       return
     }
 
+    // get menu element responsible for changing zoom
+    const zoomInputContainer = getDOMElement(
+      this.config.uiElements.clickableZoomSelectId
+    )
+    const { x: zoomInputContainerX, y: zoomInputContainerY } =
+      getDOMElementCoordinates(zoomInputContainer)
+    simulateClick(zoomInputContainer, zoomInputContainerX, zoomInputContainerY)
+
     // add check for if strategy is supported or not for app
     if (getIsCustomZoom(zoomValue)) {
-      this.uiExecuteCustomZoomFlow(zoomValue)
+      this.uiExecuteCustomZoomFlow(zoomInputContainer, zoomValue)
     } else {
-      this.uiExecuteDefinedZoomFlow(zoomValue)
+      this.uiExecuteDefinedZoomFlow(zoomInputContainer, zoomValue)
     }
   }
 
-  private uiExecuteDefinedZoomFlow(zoomValue: string) {
-    // will need to use the help menu most likely... trusted keyboard events cannot be done
-
-    // get menu element responsible for changing zoom
-    const zoomInput = getDOMElement(
-      this.config.uiElements.clickableZoomSelectId
-    )
-    const { x: zoomInputX, y: zoomInputY } = getDOMElementCoordinates(zoomInput)
-    simulateClick(zoomInput, zoomInputX, zoomInputY)
-
+  private uiExecuteDefinedZoomFlow(
+    zoomInputContainer: Element,
+    zoomValue: string
+  ) {
     // get zoom menu element dropdown
-    const zoomInputAriaOwns = zoomInput.attributes["aria-owns"].value // this is the link
+    const zoomInputContainerAriaOwns =
+      zoomInputContainer.attributes["aria-owns"].value // this is the link
     const zoomInputSelect = getDOMElement(
-      `.goog-menu.goog-menu-vertical[aria-activedescendant="${zoomInputAriaOwns}"]`
+      `.goog-menu.goog-menu-vertical[aria-activedescendant="${zoomInputContainerAriaOwns}"]`
     )
 
     // figure out zoom value to select
@@ -88,47 +91,14 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
     }, 500)
   }
 
-  private uiExecuteCustomZoomFlow(zoomValue: string) {
-    // THIS IS IMPOSSIBLE AT THE TIME DUE TO NOT BEING ABLE TO TRIGGER EVENTS BASED ON INPUTS CHANGING
-    // WILL BE LEAVING THIS HERE FOR NOW...
-
-    // open help menu
-    const helpMenu = getDOMElement(this.config.uiElements.toolbarHelpMenuId)
-    const { x: zoomInputX, y: zoomInputY } = getDOMElementCoordinates(helpMenu)
-    simulateClick(helpMenu, zoomInputX, zoomInputY)
-
-    // - find the dropdown due to client height - document.querySelectorAll(".docs-omnibox-input.jfk-textinput.label-input-label")
-
-    // find the dropdown that is visible after clicking "help"
-    const allDropdownMenus = document.querySelectorAll(
-      ".goog-menu.goog-menu-vertical.docs-material.ia-menu.ia-primary-menu"
-    )
-    console.log(allDropdownMenus)
-    const helpDropdownMenuIndex = Array.from(allDropdownMenus).findIndex(
-      (menu) => Boolean(menu.clientHeight)
-    )
-    const helpDropdownMenu = allDropdownMenus[helpDropdownMenuIndex]
-
-    console.log(helpDropdownMenu)
-    console.log(helpDropdownMenu.querySelectorAll("input"))
-
-    const helpDropdownInput = helpDropdownMenu.querySelectorAll("input")[0]
-
-    // type in "zoom 113"
-    setTimeout(() => {
-      helpDropdownInput.value = `zoom ${getNumericZoom(zoomValue)}`
-      // helpDropdownInput.select()
-      helpDropdownInput.focus()
-
-      helpDropdownInput.dispatchEvent(new InputEvent("input"))
-      helpDropdownInput.dispatchEvent(
-        new KeyboardEvent("keyup", { key: "Enter" })
-      )
-    }, 1000)
-
-    // set small timeout for dropdown / observer
-
-    // click first thing in dropdown
+  private uiExecuteCustomZoomFlow(
+    zoomInputContainer: Element,
+    zoomValue: string
+  ) {
+    // remove percentage value, convert back to string
+    const zoomInput = zoomInputContainer.querySelector("input")
+    zoomInput.value = getNumericZoom(zoomValue).toString()
+  }
 
     // thing should close
   }

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -1,4 +1,11 @@
+import { sendToBackgroundViaRelay } from "@plasmohq/messaging"
+
+import {
+  RELAY_EXECUTE_ENTER,
+  RELAY_GET_ZOOM_VALUE_FROM_STORAGE
+} from "../constants"
 import type { Feature, UiStrategyConfig } from "../types"
+import { GetZoomValueRequestBody, GetZoomValueResponseBody } from "../types"
 import getIsCustomZoom from "../utils/get-is-custom-zoom"
 import getNumericZoom from "../utils/get-numeric-zoom"
 import getZoomValueFromStorage from "../utils/get-zoom-value-from-storage"
@@ -101,6 +108,21 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
     // remove percentage value, convert back to string
     const zoomInput = zoomInputContainer.querySelector("input")
     zoomInput.value = getNumericZoom(zoomValue).toString()
+    // zoomInput.focus()
+    // zoomInput.select()
+
+    zoomInput.addEventListener("keydown", (event) => {
+      console.log(event)
+    })
+    zoomInput.addEventListener("keyup", (event) => {
+      console.log(event)
+    })
+
+    // setTimeout(() => {
+    sendToBackgroundViaRelay({
+      name: RELAY_EXECUTE_ENTER
+    }).then((res) => console.log(res))
+    // }, 1000)
   }
 
   private isFeatureEnabled(feature: Feature): boolean {

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -1,4 +1,4 @@
-import type { UiStrategyConfig } from "../types"
+import type { UiStrategyConfig, WorkspaceApp } from "../types"
 import getIsCustomZoom from "../utils/get-is-custom-zoom"
 import getNumericZoom from "../utils/get-numeric-zoom"
 import getZoomValueFromStorage from "../utils/get-zoom-value-from-storage"
@@ -17,6 +17,8 @@ export interface AbstractBaseStrategyImpl {
   // getZoomValueFromStorage: () => Promise<string>
   // uiExecuteFlow: (zoomValue: string) => void
 }
+
+type Features = keyof WorkspaceApp["features"]
 
 export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
   protected readonly config: UiStrategyConfig
@@ -46,7 +48,10 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
     simulateClick(zoomInputContainer, zoomInputContainerX, zoomInputContainerY)
 
     // add check for if strategy is supported or not for app
-    if (getIsCustomZoom(zoomValue)) {
+    if (
+      this.isFeatureEnabled("customZoomInput") &&
+      getIsCustomZoom(zoomValue)
+    ) {
       this.uiExecuteCustomZoomFlow(zoomInputContainer, zoomValue)
     } else {
       this.uiExecuteDefinedZoomFlow(zoomInputContainer, zoomValue)
@@ -100,7 +105,8 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
     zoomInput.value = getNumericZoom(zoomValue).toString()
   }
 
-    // thing should close
+  private isFeatureEnabled(feature: Features): boolean {
+    return Boolean(this.config.features[feature])
   }
 
   public getIsZoomSelectorDisabled() {

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -1,4 +1,4 @@
-import type { UiStrategyConfig, WorkspaceApp } from "../types"
+import type { Feature, UiStrategyConfig } from "../types"
 import getIsCustomZoom from "../utils/get-is-custom-zoom"
 import getNumericZoom from "../utils/get-numeric-zoom"
 import getZoomValueFromStorage from "../utils/get-zoom-value-from-storage"
@@ -17,8 +17,6 @@ export interface AbstractBaseStrategyImpl {
   // getZoomValueFromStorage: () => Promise<string>
   // uiExecuteFlow: (zoomValue: string) => void
 }
-
-type Features = keyof WorkspaceApp["features"]
 
 export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
   protected readonly config: UiStrategyConfig
@@ -105,7 +103,7 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
     zoomInput.value = getNumericZoom(zoomValue).toString()
   }
 
-  private isFeatureEnabled(feature: Features): boolean {
+  private isFeatureEnabled(feature: Feature): boolean {
     return Boolean(this.config.features[feature])
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export type ExtensionFileSource = "popup" | "content" | "background"
 
 export interface UiStrategyConfig {
   application: WorkspaceAppName
+  features: WorkspaceApp["features"]
   storageKey: StorageKey
   uiElements: {
     clickableZoomSelectId: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,3 +73,5 @@ export interface UiStrategyConfig {
     defaultZoom: string
   }
 }
+
+export type Feature = keyof WorkspaceApp["features"]

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,10 @@ export interface GetZoomValueResponseBody {
   zoomValue: string
 }
 
+export interface ExecuteEnterRequestBody {
+  zoomValue: string
+}
+
 export type WorkspaceAppName = "Docs" | "Sheets"
 
 export type DocsStorageKey = "zoomValue"


### PR DESCRIPTION
This is a potential solution to #15 (implementing custom zoom). 

In order to generate trusted events that the browser will respond to, I went the route of using `chrome.debugger` to generate these. 

This works through the following process:

1. Input custom value via popup
2. Load the google doc/sheet
3. Get the zoom value from storage
4. send a command with the zoom to the background worker (could probably just get the zoom inside the background workder by passing the key [like other things])
5. background worker attaches the debugger
6. inputs the zoom
7. initiates a "return"
8. stops the debugger

## Problems with this approach

I'm not sure I want to go with this approach because it asks for a lot of permissions (not sure if I need the active tab or the tab or something), but it asks for the debugger permission. 

This is a lot to ask for and I think it will inhibit adoption. 

## All Options
1. Use debugger and ask for all permissions
2. Don't implement functionality
3. Implement debugger functionality in a new webstore item ("Google Workspace Zoom Default - Extended" or something)
    * This will require some build process changes but could be possible 

TODO:

- [x] Get tab that is actually executing the script (problem being the the background worker will get the tab that I'm currently on, not the tab that's asking for the value. example: open dev tools on google doc, navigate to other tab, refresh inside devtools. doesn't work)