### PR TITLE
bug: don't use chrome debugger if not available

### DIFF
--- a/src/background/messages/execute-enter.ts
+++ b/src/background/messages/execute-enter.ts
@@ -1,13 +1,21 @@
 import type { PlasmoMessaging } from "@plasmohq/messaging";
-
-import type { ExecuteEnterRequestBody } from "../../types";
+import type {
+  ExecuteEnterRequestBody,
+  ExecuteEnterResponseBody
+} from "../../types";
 import { setupSentry } from "../../utils/sentry/background";
 
 const sentryClient = setupSentry("background");
 
-const handler: PlasmoMessaging.MessageHandler<ExecuteEnterRequestBody> = async (
-  req
-) => {
+const handler: PlasmoMessaging.MessageHandler<
+  ExecuteEnterRequestBody,
+  ExecuteEnterResponseBody
+> = async (req, res) => {
+  if (!chrome.debugger) {
+    res.send({ err: "no_debugger" });
+    return;
+  }
+
   try {
     const target = { tabId: req.sender.tab.id };
 
@@ -34,6 +42,7 @@ const handler: PlasmoMessaging.MessageHandler<ExecuteEnterRequestBody> = async (
     });
 
     chrome.debugger.detach(target);
+    res.send({ err: null });
   } catch (err) {
     sentryClient.captureException(err);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,10 @@ export interface ExecuteEnterRequestBody {
   zoomValue: string;
 }
 
+export interface ExecuteEnterResponseBody {
+  err: null | "no_debugger";
+}
+
 export type WorkspaceAppName = "Docs" | "Sheets";
 export type DocsZoomValueFit =
   | "Fit"


### PR DESCRIPTION
There were errors in the default application when trying to access the chrome debugger. Not sure how it's happening, but now it shouldn't. When the error is encountered we will try to find the closest defined zoom value and use that