### PR TITLE
Prune better

### DIFF
--- a/bin/remove-files.sh
+++ b/bin/remove-files.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm src/background/messages/execute-enter.ts

--- a/bin/transform-extension.mjs
+++ b/bin/transform-extension.mjs
@@ -38,6 +38,7 @@ originalPkg.manifest.browser_specific_settings.gecko.id = `${originalPkg.name}@v
 
 execaSync(path.resolve(__dirname, "./update-code-files.sh"));
 execaSync(path.resolve(__dirname, "./update-icons.sh"));
+execaSync(path.resolve(__dirname, "./remove-files.sh"));
 
 jsonfile.writeFileSync(pkgPath, originalPkg, { spaces: 2 });
 

--- a/bin/update-code-files.sh
+++ b/bin/update-code-files.sh
@@ -14,19 +14,14 @@ process_file() {
     # Read the file content
     content=$(<"$file")
     
-    # Print the original content for debugging
-    echo "Original content of $file:"
-    echo "$content"
     
-    # Remove sections between the specified comment blocks
-    modified_content=$(echo "$content" | sed -E '/\/\*--EXTENDED_ONLY_START--\*\*/,/\/\*--EXTENDED_ONLY_END--\*\*/d')
+    # Remove sections between the specified comment blocks, allowing for spaces
+    modified_content=$(echo "$content" | sed -E '/^[[:space:]]*\/\*--EXTENDED_ONLY_START--\*\//,/^[[:space:]]*\/\*--EXTENDED_ONLY_END--\*\//d')
 
     # Check if content has changed
     if [[ "$content" != "$modified_content" ]]; then
         echo "Modifying file: $file"
         echo "$modified_content" > "$file"
-    else
-        echo "No changes made to: $file"
     fi
 }
 

--- a/bin/update-code-files.sh
+++ b/bin/update-code-files.sh
@@ -3,7 +3,7 @@
 sed -i.bak -e 's/customZoomInput: true/customZoomInput: false/' src/constants.ts
 sed -i.bak -e 's/localize("extensionNameExtended")/localize("extensionName")/' src/popup.tsx
 
-# Remove code blocks that start with /* EXTENDED_ONLY_START */ and end with /* EXTENDED_ONLY_END */
+# Remove code blocks that start with /*--EXTENDED_ONLY_START--*/ and end with /*--EXTENDED_ONLY_END--*/
 start_dir="src"
 
 # Function to process each file
@@ -19,7 +19,7 @@ process_file() {
     echo "$content"
     
     # Remove sections between the specified comment blocks
-    modified_content=$(echo "$content" | sed -E '/\/\* EXTENDED_ONLY_START \*\*/,/\/\* EXTENDED_ONLY_END \*\*/d')
+    modified_content=$(echo "$content" | sed -E '/\/\*--EXTENDED_ONLY_START--\*\*/,/\/\*--EXTENDED_ONLY_END--\*\*/d')
 
     # Check if content has changed
     if [[ "$content" != "$modified_content" ]]; then

--- a/bin/update-code-files.sh
+++ b/bin/update-code-files.sh
@@ -14,7 +14,6 @@ process_file() {
     # Read the file content
     content=$(<"$file")
     
-    
     # Remove sections between the specified comment blocks, allowing for spaces
     modified_content=$(echo "$content" | sed -E '/^[[:space:]]*\/\*--EXTENDED_ONLY_START--\*\//,/^[[:space:]]*\/\*--EXTENDED_ONLY_END--\*\//d')
 
@@ -30,5 +29,9 @@ export -f process_file
 
 # Walk through all files in the directory and process them
 find "$start_dir" -type f -exec bash -c 'process_file "$0"' {} \;
+
+# Remove any .bak files created
+echo "Cleaning up .bak files..."
+find "$start_dir" -type f -name "*.bak" -exec rm -f {} \;
 
 echo "Finished processing files."

--- a/bin/update-code-files.sh
+++ b/bin/update-code-files.sh
@@ -2,3 +2,47 @@
 
 sed -i.bak -e 's/customZoomInput: true/customZoomInput: false/' src/constants.ts
 sed -i.bak -e 's/localize("extensionNameExtended")/localize("extensionName")/' src/popup.tsx
+
+# Function to remove extended content and comments from a file
+remove_extended_content() {
+  local file="$1"
+  local temp_file=$(mktemp)
+
+  if [[ ! -f "$file" ]]; then
+    echo "Error: File '$file' not found."
+    return 1
+  fi
+
+  # Check if the file has been modified
+  modified=false
+
+  while IFS= read -r line; do
+    # Check if the line is within an extended section
+    if [[ "$line" =~ /*\s*EXTENDED_ONLY_START\s*/ ]]; then
+      extended_section=true
+    elif [[ "$line" =~ /*\s*EXTENDED_ONLY_END\s*/ ]]; then
+      extended_section=false
+    fi
+
+    # Skip lines within extended sections and comments
+    if [[ ! $extended_section && ! "$line" =~ ^# ]]; then
+      echo "$line" >> "$temp_file"
+    else
+      modified=true
+    fi
+  done < "$file"
+
+  # If the file was modified, move the temporary file to the original file
+  if $modified; then
+    mv "$temp_file" "$file"
+    echo "Modified: $file"
+  else
+    rm "$temp_file"
+  fi
+}
+
+# Hardcoded starting directory
+starting_directory="src"
+
+# Walk through the directory and process files
+find "$starting_directory" -type f -exec bash -c 'remove_extended_content "$0"' {} \;

--- a/bin/update-code-files.sh
+++ b/bin/update-code-files.sh
@@ -18,8 +18,8 @@ process_file() {
     echo "Original content of $file:"
     echo "$content"
     
-    # Remove sections between comment blocks and the comments themselves
-    modified_content=$(echo "$content" | sed -E '/\/\* EXTENDED_ONLY_START \*\//, /\/\* EXTENDED_ONLY_END \*\//d; s/\/\*.*\*\///g')
+    # Remove sections between the specified comment blocks
+    modified_content=$(echo "$content" | sed -E '/\/\* EXTENDED_ONLY_START \*\*/,/\/\* EXTENDED_ONLY_END \*\*/d')
 
     # Check if content has changed
     if [[ "$content" != "$modified_content" ]]; then

--- a/bin/update-code-files.sh
+++ b/bin/update-code-files.sh
@@ -17,17 +17,23 @@ remove_extended_content() {
   modified=false
 
   while IFS= read -r line; do
+    echo "Processing line: '$line'"  # Debug log: Processing line
+
     # Check if the line is within an extended section
     if [[ "$line" =~ /*\s*EXTENDED_ONLY_START\s*/ ]]; then
       extended_section=true
+      echo "Entering extended section"  # Debug log: Entering extended section
     elif [[ "$line" =~ /*\s*EXTENDED_ONLY_END\s*/ ]]; then
       extended_section=false
+      echo "Exiting extended section"  # Debug log: Exiting extended section
     fi
 
     # Skip lines within extended sections and comments
     if [[ ! $extended_section && ! "$line" =~ ^# ]]; then
       echo "$line" >> "$temp_file"
+      echo "Writing line to temp file: '$line'"  # Debug log: Writing line to temp file
     else
+      echo "Skipping line: '$line'"  # Debug log: Skipping line
       modified=true
     fi
   done < "$file"
@@ -37,6 +43,7 @@ remove_extended_content() {
     mv "$temp_file" "$file"
     echo "Modified: $file"
   else
+    echo "No modifications made to $file"  # Debug log: No modifications made
     rm "$temp_file"
   fi
 }

--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -29,8 +29,11 @@ const sentryClient = setupSentry("content");
 const main = () => {
   // create and "register" the relay
   relayMessage({ name: RELAY_GET_ZOOM_VALUE_FROM_STORAGE });
-  relayMessage({ name: RELAY_EXECUTE_ENTER });
   relayMessage({ name: RELAY_GET_FEATURE_VIEW_ONLY_FROM_STORAGE });
+
+  /* EXTENDED_ONLY_START */
+  relayMessage({ name: RELAY_EXECUTE_ENTER });
+  /* EXTENDED_ONLY_END */
 
   const currentApp = getCurrentApp();
   let strategy: DocsStrategy | SheetsStrategy;

--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -31,9 +31,9 @@ const main = () => {
   relayMessage({ name: RELAY_GET_ZOOM_VALUE_FROM_STORAGE });
   relayMessage({ name: RELAY_GET_FEATURE_VIEW_ONLY_FROM_STORAGE });
 
-  /* EXTENDED_ONLY_START */
+  /*--EXTENDED_ONLY_START--*/
   relayMessage({ name: RELAY_EXECUTE_ENTER });
-  /* EXTENDED_ONLY_END */
+  /*--EXTENDED_ONLY_END--*/
 
   const currentApp = getCurrentApp();
   let strategy: DocsStrategy | SheetsStrategy;

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -1,5 +1,4 @@
 import { sendToBackgroundViaRelay } from "@plasmohq/messaging";
-
 import { getClosestZoomValue } from "src/utils/get-closest-zoom-value";
 import { RELAY_EXECUTE_ENTER } from "../constants";
 import type {
@@ -28,7 +27,6 @@ export interface AbstractBaseStrategyImpl {
 export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
   protected readonly config: UiStrategyConfig;
   public abstract execute(executionLocation: string): void;
-  // protected abstract getIsViewOnly(): boolean
 
   protected constructor(config: UiStrategyConfig) {
     this.config = config;
@@ -49,14 +47,19 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
       this.config.uiElements.clickableZoomSelectId
     );
 
+    /* EXTENDED_ONLY_START */
     const canUseCustomZoom =
       this.isFeatureEnabled("customZoomInput") && getIsCustomZoom(zoomValue);
 
     if (canUseCustomZoom) {
       this.uiExecuteCustomZoomFlow(zoomInputContainer, zoomValue);
     } else {
+      /* EXTENDED_ONLY_END */
+
       this.uiExecuteDefinedZoomFlow(zoomInputContainer, zoomValue);
+      /* EXTENDED_ONLY_START */
     }
+    /* EXTENDED_ONLY_END */
   }
 
   private uiExecuteDefinedZoomFlow(
@@ -92,6 +95,7 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
     this.closeDropdown();
   }
 
+  /* EXTENDED_ONLY_START */
   private uiExecuteCustomZoomFlow(
     zoomInputContainer: Element,
     zoomValue: string
@@ -123,6 +127,7 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
       }
     });
   }
+  /* EXTENDED_ONLY_END */
 
   private closeDropdown() {
     // close dropdown with blur event (may need to check again to see if it's closed)

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -47,19 +47,19 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
       this.config.uiElements.clickableZoomSelectId
     );
 
-    /* EXTENDED_ONLY_START */
+    /*--EXTENDED_ONLY_START--*/
     const canUseCustomZoom =
       this.isFeatureEnabled("customZoomInput") && getIsCustomZoom(zoomValue);
 
     if (canUseCustomZoom) {
       this.uiExecuteCustomZoomFlow(zoomInputContainer, zoomValue);
     } else {
-      /* EXTENDED_ONLY_END */
+      /*--EXTENDED_ONLY_END--*/
 
       this.uiExecuteDefinedZoomFlow(zoomInputContainer, zoomValue);
-      /* EXTENDED_ONLY_START */
+      /*--EXTENDED_ONLY_START--*/
     }
-    /* EXTENDED_ONLY_END */
+    /*--EXTENDED_ONLY_END--*/
   }
 
   private uiExecuteDefinedZoomFlow(
@@ -95,7 +95,7 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
     this.closeDropdown();
   }
 
-  /* EXTENDED_ONLY_START */
+  /*--EXTENDED_ONLY_START--*/
   private uiExecuteCustomZoomFlow(
     zoomInputContainer: Element,
     zoomValue: string
@@ -127,7 +127,7 @@ export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
       }
     });
   }
-  /* EXTENDED_ONLY_END */
+  /*--EXTENDED_ONLY_END--*/
 
   private closeDropdown() {
     // close dropdown with blur event (may need to check again to see if it's closed)


### PR DESCRIPTION
Actually remove code that's not needed in the default extension. This introduces the idea that when transforming the code from the extended version to the default version, anything between comments like below will be removed:

```js
/*--EXTENDED_ONLY_START--*/

... code to be removed

/*--EXTENDED_ONLY_END--*/
```