### PR TITLE
feat(sentry): use custom error boundary

### DIFF
--- a/src/components/ErrorFallback/index.tsx
+++ b/src/components/ErrorFallback/index.tsx
@@ -1,9 +1,11 @@
+import * as styles from "../../style.module.css";
+
 type Props = {
   heading: string;
 };
 
 export const ErrorFallback = ({ heading }: Props) => (
-  <>
+  <div className={styles.popupContainer} style={{ minHeight: "unset" }}>
     <h1>{heading}</h1>
     <p>
       Sorry! Something has gone wrong. Please submit an issue{" "}
@@ -12,5 +14,5 @@ export const ErrorFallback = ({ heading }: Props) => (
       </a>{" "}
       so I can fix it!
     </p>
-  </>
+  </div>
 );

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -8,8 +8,8 @@ import { isChrome, isEdge } from "src/utils/get-browser";
 import localize from "src/utils/localize";
 import { setupSentryReactErrorBoundary } from "src/utils/sentry/react-error-boundary";
 
-const showExtensionVersionsTab = isChrome() || isEdge();
 const withSentryErrorBoundary = setupSentryReactErrorBoundary("popup");
+const showExtensionVersionsTab = isChrome() || isEdge();
 
 // "extensionName"/"extensionNameExtended" WILL BE CHANGED. DON'T CHANGE WITHOUT MAKING OTHER CHANGES
 const extensionName = localize("extensionNameExtended");

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -6,9 +6,9 @@ import * as styles from "src/style.module.css";
 import type { CurrentView } from "src/types";
 import { isChrome, isEdge } from "src/utils/get-browser";
 import localize from "src/utils/localize";
-import { setupSentryReactErrorBoundary } from "src/utils/sentry/react-error-boundary";
+import ErrorBoundary from "src/utils/sentry/react-error-boundary";
+import { ErrorFallback } from "./components/ErrorFallback";
 
-const withSentryErrorBoundary = setupSentryReactErrorBoundary("popup");
 const showExtensionVersionsTab = isChrome() || isEdge();
 
 // "extensionName"/"extensionNameExtended" WILL BE CHANGED. DON'T CHANGE WITHOUT MAKING OTHER CHANGES
@@ -30,26 +30,28 @@ function IndexPopup() {
 
   return (
     <div className={styles.popupContainer}>
-      <h1>{extensionName}</h1>
-      {isHomeView ? (
-        <HomeView
-          openSettingsView={openSettingsView}
-          showExtensionVersionsTab={showExtensionVersionsTab}
-        />
-      ) : null}
-      {isSettingsView ? <SettingsView onHomeClick={openHomeView} /> : null}
+      <ErrorBoundary fallback={<ErrorFallback heading={extensionName} />}>
+        <h1>{extensionName}</h1>
+        {isHomeView ? (
+          <HomeView
+            openSettingsView={openSettingsView}
+            showExtensionVersionsTab={showExtensionVersionsTab}
+          />
+        ) : null}
+        {isSettingsView ? <SettingsView onHomeClick={openHomeView} /> : null}
 
-      <p className={styles.supportMeLinkContainer}>
-        <small>
-          💚{" "}
-          <a href="https://buymeacoffee.com/vernacchia">
-            {localize("popupSupportMeLabel")}
-          </a>{" "}
-          🤟
-        </small>
-      </p>
+        <p className={styles.supportMeLinkContainer}>
+          <small>
+            💚{" "}
+            <a href="https://buymeacoffee.com/vernacchia">
+              {localize("popupSupportMeLabel")}
+            </a>{" "}
+            🤟
+          </small>
+        </p>
+      </ErrorBoundary>
     </div>
   );
 }
 
-export default withSentryErrorBoundary(IndexPopup, extensionName);
+export default IndexPopup;

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -6,10 +6,10 @@ import * as styles from "src/style.module.css";
 import type { CurrentView } from "src/types";
 import { isChrome, isEdge } from "src/utils/get-browser";
 import localize from "src/utils/localize";
-import ErrorBoundary from "src/utils/sentry/react-error-boundary";
-import { ErrorFallback } from "./components/ErrorFallback";
+import { setupSentryReactErrorBoundary } from "src/utils/sentry/react-error-boundary";
 
 const showExtensionVersionsTab = isChrome() || isEdge();
+const withSentryErrorBoundary = setupSentryReactErrorBoundary("popup");
 
 // "extensionName"/"extensionNameExtended" WILL BE CHANGED. DON'T CHANGE WITHOUT MAKING OTHER CHANGES
 const extensionName = localize("extensionNameExtended");
@@ -30,28 +30,26 @@ function IndexPopup() {
 
   return (
     <div className={styles.popupContainer}>
-      <ErrorBoundary fallback={<ErrorFallback heading={extensionName} />}>
-        <h1>{extensionName}</h1>
-        {isHomeView ? (
-          <HomeView
-            openSettingsView={openSettingsView}
-            showExtensionVersionsTab={showExtensionVersionsTab}
-          />
-        ) : null}
-        {isSettingsView ? <SettingsView onHomeClick={openHomeView} /> : null}
+      <h1>{extensionName}</h1>
+      {isHomeView ? (
+        <HomeView
+          openSettingsView={openSettingsView}
+          showExtensionVersionsTab={showExtensionVersionsTab}
+        />
+      ) : null}
+      {isSettingsView ? <SettingsView onHomeClick={openHomeView} /> : null}
 
-        <p className={styles.supportMeLinkContainer}>
-          <small>
-            💚{" "}
-            <a href="https://buymeacoffee.com/vernacchia">
-              {localize("popupSupportMeLabel")}
-            </a>{" "}
-            🤟
-          </small>
-        </p>
-      </ErrorBoundary>
+      <p className={styles.supportMeLinkContainer}>
+        <small>
+          💚{" "}
+          <a href="https://buymeacoffee.com/vernacchia">
+            {localize("popupSupportMeLabel")}
+          </a>{" "}
+          🤟
+        </small>
+      </p>
     </div>
   );
 }
 
-export default IndexPopup;
+export default withSentryErrorBoundary(IndexPopup, extensionName);

--- a/src/utils/sentry/base.ts
+++ b/src/utils/sentry/base.ts
@@ -1,4 +1,3 @@
-// This is used in both content and background scripts. Do not use this in the popup.
 import {
   BrowserClient,
   Scope,
@@ -6,10 +5,14 @@ import {
   getDefaultIntegrations,
   makeFetchTransport
 } from "@sentry/browser";
+import type { BrowserClientOptions } from "@sentry/browser/build/npm/types/client";
 import type { ExtensionFileSource } from "src/types";
 import { SENTRY_BASE_CONFIG, getDefaultTags } from "./config";
 
-const createNewSentryClient = (source: ExtensionFileSource): Scope => {
+const createNewSentryClient = (
+  source: ExtensionFileSource,
+  browserClientOptions: Partial<BrowserClientOptions>
+): Scope => {
   const sentryClient = new BrowserClient({
     ...SENTRY_BASE_CONFIG,
     stackParser: defaultStackParser,
@@ -18,7 +21,8 @@ const createNewSentryClient = (source: ExtensionFileSource): Scope => {
         defaultIntegration.name
       );
     }),
-    transport: makeFetchTransport
+    transport: makeFetchTransport,
+    ...browserClientOptions
   });
 
   const sentryScope = new Scope();

--- a/src/utils/sentry/react-error-boundary.tsx
+++ b/src/utils/sentry/react-error-boundary.tsx
@@ -1,5 +1,5 @@
 import { getDefaultIntegrations, Scope } from "@sentry/browser";
-import { Component } from "react";
+import { Component, type ComponentType, type ReactNode } from "react";
 import { ErrorFallback } from "src/components/ErrorFallback";
 import type { ExtensionFileSource } from "src/types";
 import { createSentryClient } from "./base";
@@ -9,8 +9,8 @@ type ErrorBoundaryState = {
 };
 
 type ErrorBoundaryProps = {
-  fallback: React.ReactNode;
-  children: React.ReactNode;
+  fallback: ReactNode;
+  children: ReactNode;
   sentryScope: Scope;
 };
 
@@ -58,11 +58,13 @@ export const setupSentryReactErrorBoundary = (source: ExtensionFileSource) => {
     integrations: getDefaultIntegrations({})
   });
 
-  return (children, fallbackHeading) => {
-    <ErrorBoundaryWithSentry
-      sentryScope={sentryScope}
-      fallback={<ErrorFallback heading={fallbackHeading} />}>
-      {children}
-    </ErrorBoundaryWithSentry>;
+  return (WrappedComponent: ComponentType, fallbackHeading: string) => {
+    return () => (
+      <ErrorBoundaryWithSentry
+        sentryScope={sentryScope}
+        fallback={<ErrorFallback heading={fallbackHeading} />}>
+        <WrappedComponent />
+      </ErrorBoundaryWithSentry>
+    );
   };
 };

--- a/src/utils/sentry/react-error-boundary.tsx
+++ b/src/utils/sentry/react-error-boundary.tsx
@@ -1,19 +1,57 @@
-import * as Sentry from "@sentry/react";
-import { ErrorFallback } from "src/components/ErrorFallback";
-import type { ExtensionFileSource } from "src/types";
-import { SENTRY_BASE_CONFIG, getDefaultTags, setLocaleOnScope } from "./config";
+import { getDefaultIntegrations } from "@sentry/browser";
+import { Component } from "react";
+import { createSentryClient } from "./base";
 
-export const setupSentryReactErrorBoundary = (source: ExtensionFileSource) => {
-  Sentry.init(SENTRY_BASE_CONFIG);
-  Sentry.getCurrentScope().setTags({ source, ...getDefaultTags() });
-
-  return (
-    component: React.ComponentType<Record<string, any>>,
-    fallbackHeading: string
-  ) => {
-    return Sentry.withErrorBoundary(component, {
-      fallback: <ErrorFallback heading={fallbackHeading} />,
-      beforeCapture: setLocaleOnScope
-    });
-  };
+type ErrorBoundaryState = {
+  hasError: boolean;
 };
+
+type ErrorBoundaryProps = {
+  fallback: React.ReactNode;
+  children: React.ReactNode;
+};
+
+const sentryScope = createSentryClient("popup", {
+  integrations: getDefaultIntegrations({})
+});
+
+class ErrorBoundaryWithSentry extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    sentryScope.captureException(error, {
+      ...{
+        mechanism: {
+          handled: Boolean(this.props.fallback)
+        }
+      },
+      captureContext: {
+        contexts: {
+          react: { componentStack: info.componentStack }
+        }
+      }
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundaryWithSentry;


### PR DESCRIPTION
to stop getting rejected from stores, need to remove sentry lazy load implementation that is bundled when using `Sentry.init` (i believe).

```
popup.cc3817b7.js: " let u = function(e) { let t = (0, o.getClient)(), r = t && t.getOptions(), n = r && r.cdnBaseUrl || "https://browser.sentry-cdn.com/"; return new URL(`/${(0,o.SDK_VERSION)}/${e}.min.js`, n).toString() }(r), c = (0, s.WINDOW).document.createElement("script"); c.src = u, c.crossOrigin = "anonymous", c.referrerPolicy = "origin", t && c.setAttribute("nonce", t); let p = new Promise((e, t) => { c.addEventListener("load", () => e()), c.addEventListener("error", t) }), d = s.WINDOW.document.currentScript,"
```