### PR TITLE
feat(preview): move preview check into strategies

### DIFF
--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -67,7 +67,7 @@ const main = () => {
   }
 
   // Do not execute if there's no supported strategy or the URL indicates the "doc" being previewed
-  const shouldExecute = strategy && !strategy.isPreview(window.location.href);
+  const shouldExecute = strategy && !strategy.isUIPreview(window.location.href);
 
   if (shouldExecute) {
     const counter = counterFactory();

--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -66,7 +66,10 @@ const main = () => {
       break;
   }
 
-  if (strategy) {
+  // Do not execute if there's no supported strategy or the URL indicates the "doc" being previewed
+  const shouldExecute = strategy && !strategy.isPreview(window.location.href);
+
+  if (shouldExecute) {
     const counter = counterFactory();
     const observer = new MutationObserver((_mutationList, observer) => {
       const { isLoading } = strategy.getIsPageLoading();

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -22,11 +22,13 @@ export interface AbstractBaseStrategyImpl {
     isLoading: boolean;
     getElementToWatch: () => Element;
   };
+  isPreview: (href: string) => boolean;
 }
 
 export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
   protected readonly config: UiStrategyConfig;
   public abstract execute(executionLocation: string): void;
+  public abstract isPreview(href: string): boolean;
 
   protected constructor(config: UiStrategyConfig) {
     this.config = config;

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -22,13 +22,13 @@ export interface AbstractBaseStrategyImpl {
     isLoading: boolean;
     getElementToWatch: () => Element;
   };
-  isPreview: (href: string) => boolean;
+  isUIPreview: (href: string) => boolean;
 }
 
 export abstract class AbstractBaseStrategy implements AbstractBaseStrategyImpl {
   protected readonly config: UiStrategyConfig;
   public abstract execute(executionLocation: string): void;
-  public abstract isPreview(href: string): boolean;
+  public abstract isUIPreview(href: string): boolean;
 
   protected constructor(config: UiStrategyConfig) {
     this.config = config;

--- a/src/strategies/docs.ts
+++ b/src/strategies/docs.ts
@@ -38,7 +38,7 @@ class DocsStrategy
    *
    * example preview URL: "/document/d/XXXX/preview"
    */
-  public isPreview(href: string): boolean {
+  public isUIPreview(href: string): boolean {
     const { pathname } = new URL(href);
 
     const docsPreviewRegex = /\/preview$/;

--- a/src/strategies/docs.ts
+++ b/src/strategies/docs.ts
@@ -33,6 +33,23 @@ class DocsStrategy
     });
   }
 
+  /**
+   * This function tells us if the doc is in preview mode. There is no menu in preview mode, so we can't zoom
+   *
+   * example preview URL: "/document/d/XXXX/preview"
+   */
+  public isPreview(href: string): boolean {
+    const { pathname } = new URL(href);
+
+    const docsPreviewRegex = /\/preview$/;
+
+    if (docsPreviewRegex.test(pathname)) {
+      return true;
+    }
+
+    return false;
+  }
+
   /*
    * This function determines if the page is in view only mode
    * */

--- a/src/strategies/sheets.ts
+++ b/src/strategies/sheets.ts
@@ -15,6 +15,22 @@ class SheetsStrategy
     });
   }
 
+  /**
+   * This function tells us if the sheets is in preview mode. There is no menu in preview mode, so we can't zoom
+   *
+   * example preview URL: "/spreadsheets/u/0/d/XXXX-XX/preview/sheet";
+   */
+  public isPreview(href: string): boolean {
+    const { pathname } = new URL(href);
+    const sheetsPreviewRegex = /\/preview\/sheet$/;
+
+    if (sheetsPreviewRegex.test(pathname)) {
+      return true;
+    }
+
+    return false;
+  }
+
   // getIsViewOnly() {
   //   return false
   // }

--- a/src/strategies/sheets.ts
+++ b/src/strategies/sheets.ts
@@ -20,7 +20,7 @@ class SheetsStrategy
    *
    * example preview URL: "/spreadsheets/u/0/d/XXXX-XX/preview/sheet";
    */
-  public isPreview(href: string): boolean {
+  public isUIPreview(href: string): boolean {
     const { pathname } = new URL(href);
     const sheetsPreviewRegex = /\/preview\/sheet$/;
 

--- a/src/strategies/sheets.ts
+++ b/src/strategies/sheets.ts
@@ -19,12 +19,18 @@ class SheetsStrategy
    * This function tells us if the sheets is in preview mode. There is no menu in preview mode, so we can't zoom
    *
    * example preview URL: "/spreadsheets/u/0/d/XXXX-XX/preview/sheet";
+   * example preview URL: "/spreadsheets/u/0/d/XXXX-XX/preview";
    */
   public isUIPreview(href: string): boolean {
     const { pathname } = new URL(href);
-    const sheetsPreviewRegex = /\/preview\/sheet$/;
+    const sheetsPreviewRegex1 = /\/preview\/sheet$/;
+    const sheetsPreviewRegex2 = /\/preview$/;
 
-    if (sheetsPreviewRegex.test(pathname)) {
+    if (sheetsPreviewRegex1.test(pathname)) {
+      return true;
+    }
+
+    if (sheetsPreviewRegex2.test(pathname)) {
       return true;
     }
 

--- a/src/utils/stop-exeuction.ts
+++ b/src/utils/stop-exeuction.ts
@@ -6,23 +6,5 @@ export const stopExecution = (currentApp: WorkspaceAppName | null): boolean => {
     return true;
   }
 
-  // '/document/d/XXXX/preview'
-  // "/spreadsheets/u/0/d/XXXX-XX/preview/sheet";
-  const { pathname } = new URL(window.location.href);
-
-  if (currentApp === "Docs") {
-    const docsPreviewRegex = /\/preview$/;
-
-    if (docsPreviewRegex.test(pathname)) {
-      return true;
-    }
-  } else if (currentApp === "Sheets") {
-    const sheetsPreviewRegex = /\/preview\/sheet$/;
-
-    if (sheetsPreviewRegex.test(pathname)) {
-      return true;
-    }
-  }
-
   return false;
 };


### PR DESCRIPTION
i encompass "view only" checking in the different strategies, so I should be consistent and put the preview check there as well.