### PR TITLE
Rename extension because edge store won't accept

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -34,7 +34,7 @@ jobs:
           pnpm package --target=chrome-mv3
           pnpm package --target=edge-mv3
           pnpm package --target=firefox-mv2
-      - name: Transform to "Google Workspace Zoom Default"
+      - name: Transform to "Default zoom for Google Workspace"
         run: pnpm transform-ext
       - name: Build the extension
         run: |

--- a/.github/workflows/submit-extended.yml
+++ b/.github/workflows/submit-extended.yml
@@ -1,4 +1,4 @@
-#This is exactly the same as the default one minus the "Transform to "Google Workspace Zoom Default"" and Sentry steps
+#This is exactly the same as the default one minus the "Transform to "Default zoom for Google Workspace"" and Sentry steps
 name: "(extended) Submit to Web Store"
 on:
   workflow_dispatch:
@@ -69,7 +69,7 @@ jobs:
           keys: ${{ secrets.SUBMIT_KEYS_EXTENDED }}
           chrome-file: build/chrome-mv3-prod.zip
           edge-file: build/edge-mv3-prod.zip
-          edge-notes: "Publishing latest 'Google Workspace Zoom Default - Extended' version (${{ steps.package-version.outputs.current-version }}) to Edge Store."
+          edge-notes: "Publishing latest 'Default zoom for Google Workspace (Extended)' version (${{ steps.package-version.outputs.current-version }}) to Edge Store."
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -29,7 +29,7 @@ jobs:
         run: pnpm install
       - name: Run Tests
         run: pnpm test
-      - name: Transform to "Google Workspace Zoom Default"
+      - name: Transform to "Default zoom for Google Workspace"
         run: pnpm transform-ext
       - name: Build the extension
         run: |
@@ -82,7 +82,7 @@ jobs:
           keys: ${{ secrets.SUBMIT_KEYS }}
           chrome-file: build/chrome-mv3-prod.zip
           edge-file: build/edge-mv3-prod.zip
-          edge-notes: "Publishing latest 'Google Workspace Zoom Default' version (${{ steps.package-version.outputs.current-version }}) to Edge Store."
+          edge-notes: "Publishing latest 'Default zoom for Google Workspace' version (${{ steps.package-version.outputs.current-version }}) to Edge Store."
           firefox-file: build/firefox-mv2-prod.zip
       - uses: actions/upload-artifact@v4
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Google Workspace Zoom Default
+# Default zoom for Google Workspace
+
+<small>Formerly _"Google Workspace Zoom Default"_. Stupid Edge store...</small>
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://buymeacoffee.com/vernacchia)
 
@@ -19,26 +21,26 @@ Supported Google Workspace Products:
 
 ## Browser Support
 
-|                                          | Chrome Extension | Microsoft Edge Add-ons | Firefox Add-ons |
-| ---------------------------------------- | ---------------- | ---------------------- | --------------- |
-| Google Workspace Zoom Default            | ✅               | ✅                     | ✅              |
-| Google Workspace Zoom Default - Extended | ✅               | ✅                     | ❌              |
+|                                              | Chrome Extension | Microsoft Edge Add-ons | Firefox Add-ons |
+|----------------------------------------------| ---------------- | ---------------------- | --------------- |
+| Default zoom for Google Workspace            | ✅               | ✅                     | ✅              |
+| Default zoom for Google Workspace (Extended) | ✅               | ✅                     | ❌              |
 
 ### Find it on Chrome Web Store
 
-- [Google Workspace Zoom Default][chrome-webstore-default]
-- [Google Workspace Zoom Default - Extended][chrome-webstore-extended]
+- [Default zoom for Google Workspace][chrome-webstore-default]
+- [Default zoom for Google Workspace (Extended)][chrome-webstore-extended]
   - In exchange for allowing elevated permissions, this extension provides ability to set custom zoom levels (as opposed to only predefined values)
 
 ### Find it on Microsoft Edge Add-ons
 
-- [Google Workspace Zoom Default][edge-addons-default]
-- [Google Workspace Zoom Default - Extended][edge-addons-extended]
+- [Default zoom for Google Workspace][edge-addons-default]
+- [Default zoom for Google Workspace (Extended)][edge-addons-extended]
   - In exchange for allowing elevated permissions, this extension provides ability to set custom zoom levels (as opposed to only predefined values)
 
 ### Find it on Firefox Add-ons
 
-- [Google Workspace Zoom Default][firefox-addons-default]
+- [Default zoom for Google Workspace][firefox-addons-default]
 
 :rotating_light: **NOTE:** Firefox does not support the "debugger" permission, meaning custom zoom values are not supported
 

--- a/bin/transform-extension.mjs
+++ b/bin/transform-extension.mjs
@@ -1,5 +1,5 @@
 /**
- * This script aims to transform this extension from "Google Workspace Zoom Default - Extended" to "Google Workspace Zoom Default"
+ * This script aims to transform this extension from "Default zoom for Google Workspace (Extended)" to "Default zoom for Google Workspace"
  *
  * In order to do this, this script needs to do thw following:
  * 1. Remove "debugger" permissions from the package.json -> mainfest -> permissiosn array

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -1,10 +1,10 @@
 {
   "extensionName": {
-    "message": "Google Workspace Standard-Zoom",
+    "message": "Standardzoom für Google Workspace",
     "description": "Name of the extension."
   },
   "extensionNameExtended": {
-    "message": "Google Workspace Standard-Zoom – Erweitert",
+    "message": "Standardzoom für Google Workspace (Erweitert)",
     "description": "Name of the extension with extra features requiring higher permissions"
   },
   "extensionDescription": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1,10 +1,10 @@
 {
   "extensionName": {
-    "message": "Google Workspace Zoom Default",
+    "message": "Default zoom for Google Workspace",
     "description": "Name of the extension."
   },
   "extensionNameExtended": {
-    "message": "Google Workspace Zoom Default - Extended",
+    "message": "Default zoom for Google Workspace (Extended)",
     "description": "Name of the extension with extra features requiring higher permissions"
   },
   "extensionDescription": {

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -1,10 +1,10 @@
 {
   "extensionName": {
-    "message": "Zoom predeterminado de Google Workspace",
+    "message": "Zoom predeterminado para Google Workspace",
     "description": "Name of the extension."
   },
   "extensionNameExtended": {
-    "message": "Zoom predeterminado de Google Workspace - Extendido",
+    "message": "Zoom predeterminado para Google Workspace (Extendido)",
     "description": "Name of the extension with extra features requiring higher permissions"
   },
   "extensionDescription": {

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -1,10 +1,10 @@
 {
   "extensionName": {
-    "message": "Zoom par défaut de Google Workspace",
+    "message": "Zoom par défaut pour Google Workspace",
     "description": "Name of the extension."
   },
   "extensionNameExtended": {
-    "message": "Zoom par défaut de Google Workspace - Étendu",
+    "message": "Zoom par défaut pour Google Workspace (Étendu)",
     "description": "Name of the extension with extra features requiring higher permissions"
   },
   "extensionDescription": {

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -1,10 +1,10 @@
 {
   "extensionName": {
-    "message": "Zoom predefinito di Google Workspace",
+    "message": "Zoom predefinito per Google Workspace",
     "description": "Nome dell'estensione."
   },
   "extensionNameExtended": {
-    "message": "Zoom predefinito di Google Workspace - Esteso",
+    "message": "Zoom predefinito per Google Workspace (Esteso)",
     "description": "Nome dell'estensione con funzionalità extra che richiedono autorizzazioni più elevate"
   },
   "extensionDescription": {

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -1,10 +1,10 @@
 {
   "extensionName": {
-    "message": "Google Workspace ズームのデフォルト",
+    "message": "Google Workspace のデフォルトズーム",
     "description": "Name of the extension."
   },
   "extensionNameExtended": {
-    "message": "Google Workspace Zoom デフォルト - 拡張",
+    "message": "Google Workspace のデフォルトズーム (拡張)",
     "description": "Name of the extension with extra features requiring higher permissions"
   },
   "extensionDescription": {

--- a/locales/ru/messages.json
+++ b/locales/ru/messages.json
@@ -1,10 +1,10 @@
 {
   "extensionName": {
-    "message": "Google Workspace - Масштаб по умолчанию",
+    "message": "Стандартный масштаб для Google Workspace",
     "description": "Название расширения."
   },
   "extensionNameExtended": {
-    "message": "Google Workspace - Масштаб по умолчанию - Расширенная версия",
+    "message": "Стандартный масштаб для Google Workspace (Расширенный)",
     "description": "Название расширения с дополнительными функциями, требующими более высоких разрешений"
   },
   "extensionDescription": {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -6,7 +6,7 @@ class Logger {
   }
 
   info(msg) {
-    console.log(`Google Workspace Zoom Default: ${msg}`);
+    console.log(`Default zoom for Google Workspace: ${msg}`);
   }
 }
 


### PR DESCRIPTION
Due to the usage of "Google" and "Zoom" in the name, the Edge Store will not accept my extension updates. It seems "Zoom" has a corner on all usages of the dictionary word of "zoom" and that Title Case is not allowed...

So, to not have to have inconsistencies across stores, I've decided to rename it. Now I have to rename all the shit on my blogssssss.... fun fun