### PR TITLE
feat: implement TanStack Router with tab-based navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,15 +109,19 @@ Use the following markers for code that should only exist in the "Extended" vers
 When tasking with addressing PR reviews or managing the PR lifecycle, follow this workflow:
 
 ### 1. Verification
+
 - **Tests:** **ALWAYS** run tests using `pnpm test -- --run` (or similar non-watching flags) to ensure the process terminates automatically.
 - **Build:** Run `pnpm build` to verify the extension bundles correctly.
 - **Format/Lint:** Run `pnpm format` and `pnpm lint` as per the mandatory workflow.
 
 ### 2. Addressing Reviews
+
 - **Fetch Comments:** Use `gh api repos/{owner}/{repo}/pulls/{number}/comments` to read latest feedback.
 - **Action Comments:** Implement requested changes surgically.
 - **Resolve Threads:** After pushing fixes, resolve the corresponding review threads using the GitHub GraphQL API (`resolveReviewThread` mutation). This provides clear visual feedback that a comment has been addressed.
 - **Re-request Review:** Use `gh pr edit {number} --add-reviewer {login}` or `gh pr comment` to notify reviewers of the updates.
 
 ### 3. Pushing Changes
+
+- **Format & Lint:** **ALWAYS** run `pnpm format` and `pnpm lint` immediately before pushing. Pushing unformatted code is a failure.
 - Ensure all commits follow the existing style and that the remote branch is kept up to date (`git push`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,21 @@ Use the following markers for code that should only exist in the "Extended" vers
 // Extended-only logic here
 /*--EXTENDED_ONLY_END--*/
 ```
+
+## Pull Request & Code Review Workflow
+
+When tasking with addressing PR reviews or managing the PR lifecycle, follow this workflow:
+
+### 1. Verification
+- **Tests:** **ALWAYS** run tests using `pnpm test -- --run` (or similar non-watching flags) to ensure the process terminates automatically.
+- **Build:** Run `pnpm build` to verify the extension bundles correctly.
+- **Format/Lint:** Run `pnpm format` and `pnpm lint` as per the mandatory workflow.
+
+### 2. Addressing Reviews
+- **Fetch Comments:** Use `gh api repos/{owner}/{repo}/pulls/{number}/comments` to read latest feedback.
+- **Action Comments:** Implement requested changes surgically.
+- **Resolve Threads:** After pushing fixes, resolve the corresponding review threads using the GitHub GraphQL API (`resolveReviewThread` mutation). This provides clear visual feedback that a comment has been addressed.
+- **Re-request Review:** Use `gh pr edit {number} --add-reviewer {login}` or `gh pr comment` to notify reviewers of the updates.
+
+### 3. Pushing Changes
+- Ensure all commits follow the existing style and that the remote branch is kept up to date (`git push`).

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -35,14 +35,17 @@ The easiest way to deploy your Plasmo extension is to use the built-in [bpp](htt
 ## Development Tips
 
 ### Requesting PR Reviews from GitHub Copilot
+
 You can request a review from GitHub Copilot using the following commands:
 
 Using `gh pr edit`:
+
 ```bash
 gh pr edit <pr-number-or-url> --add-reviewer @copilot
 ```
 
 Or when creating a new PR:
+
 ```bash
 gh pr create --add-reviewer @copilot
 ```

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -39,10 +39,10 @@ You can request a review from GitHub Copilot using the following commands:
 
 Using `gh pr edit`:
 ```bash
-gh pr edit <pr-number-or-url> --add-reviewer @.idea/copilot.data.migration.agent.xml
+gh pr edit <pr-number-or-url> --add-reviewer @copilot
 ```
 
 Or when creating a new PR:
 ```bash
-gh pr create --add-reviewer @.idea/copilot.data.migration.agent.xml
+gh pr create --add-reviewer @copilot
 ```

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -31,3 +31,18 @@ This should create a production bundle for your extension, ready to be zipped an
 ## Submit to the webstores
 
 The easiest way to deploy your Plasmo extension is to use the built-in [bpp](https://bpp.browser.market) GitHub action. Prior to using this action however, make sure to build your extension and upload the first version to the store to establish the basic credentials. Then, simply follow [this setup instruction](https://docs.plasmo.com/framework/workflows/submit) and you should be on your way for automated submission!
+
+## Development Tips
+
+### Requesting PR Reviews from GitHub Copilot
+You can request a review from GitHub Copilot using the following commands:
+
+Using `gh pr edit`:
+```bash
+gh pr edit <pr-number-or-url> --add-reviewer @.idea/copilot.data.migration.agent.xml
+```
+
+Or when creating a new PR:
+```bash
+gh pr create --add-reviewer @.idea/copilot.data.migration.agent.xml
+```

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -142,5 +142,13 @@
   "popupSettingsStorageVersion": {
     "message": "Storage v{schemaVersion}",
     "description": "Text in settings footer denoting current storage schema version"
+  },
+  "popupNavHome": {
+    "message": "Home",
+    "description": "Label for the Home navigation tab"
+  },
+  "popupNavSettings": {
+    "message": "Settings",
+    "description": "Label for the Settings navigation tab"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,14 +26,13 @@
     "@plasmohq/storage": "^1.15.0",
     "@sentry/browser": "^9.40.0",
     "@sentry/react": "^9.40.0",
-    "@tippyjs/react": "^4.2.6",
+    "@tanstack/react-router": "^1.168.10",
     "classnames": "^2.5.1",
     "plasmo": "0.90.5",
     "react": "18.2.0",
     "react-aria-components": "^1.6.0",
     "react-dom": "18.2.0",
     "react-hot-toast": "^2.6.0",
-    "tippy.js": "^6.3.7",
     "tslog": "^4.9.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,9 @@ importers:
       '@sentry/react':
         specifier: ^9.40.0
         version: 9.40.0(react@18.2.0)
-      '@tippyjs/react':
-        specifier: ^4.2.6
-        version: 4.2.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tanstack/react-router':
+        specifier: ^1.168.10
+        version: 1.168.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -44,9 +44,6 @@ importers:
       react-hot-toast:
         specifier: ^2.6.0
         version: 2.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      tippy.js:
-        specifier: ^6.3.7
-        version: 6.3.7
       tslog:
         specifier: ^4.9.3
         version: 4.9.3
@@ -2161,9 +2158,6 @@ packages:
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
 
-  '@popperjs/core@2.11.8':
-    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
-
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -3352,6 +3346,31 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
+  '@tanstack/history@1.161.6':
+    resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/react-router@1.168.10':
+    resolution: {integrity: sha512-/RmDlOwDkCug609KdPB3U+U1zmrtadJpvsmRg2zEn8TRCKRNri7dYZIjQZbNg8PgUiRL4T6njrZBV1ChzblNaA==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.168.9':
+    resolution: {integrity: sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g==}
+    engines: {node: '>=20.19'}
+    hasBin: true
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
@@ -3365,12 +3384,6 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
-
-  '@tippyjs/react@4.2.6':
-    resolution: {integrity: sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
 
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -3847,6 +3860,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@2.0.1:
+    resolution: {integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==}
 
   copy-anything@2.0.6:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
@@ -4566,6 +4582,10 @@ packages:
   isbinaryfile@4.0.10:
     resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
     engines: {node: '>= 8.0.0'}
+
+  isbot@5.1.37:
+    resolution: {integrity: sha512-5bcicX81xf6NlTEV8rWdg7Pk01LFizDetuYGHx6d/f6y3lR2/oo8IfxjzJqn1UdDEyCcwT9e7NRloj8DwCYujQ==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -5455,6 +5475,16 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  seroval-plugins@1.5.2:
+    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.2:
+    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+    engines: {node: '>=10'}
+
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -5661,9 +5691,6 @@ packages:
     resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
 
-  tippy.js@6.3.7:
-    resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
-
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -5816,6 +5843,11 @@ packages:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -8221,8 +8253,6 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@popperjs/core@2.11.8': {}
-
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -9771,6 +9801,33 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@tanstack/history@1.161.6': {}
+
+  '@tanstack/react-router@1.168.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-store': 0.9.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tanstack/router-core': 1.168.9
+      isbot: 5.1.37
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@tanstack/react-store@0.9.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      use-sync-external-store: 1.6.0(react@18.2.0)
+
+  '@tanstack/router-core@1.168.9':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      cookie-es: 2.0.1
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
+
+  '@tanstack/store@0.9.3': {}
+
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -9795,12 +9852,6 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
-
-  '@tippyjs/react@4.2.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      tippy.js: 6.3.7
 
   '@tootallnate/once@2.0.0': {}
 
@@ -10318,6 +10369,8 @@ snapshots:
   content-security-policy-parser@0.4.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-es@2.0.1: {}
 
   copy-anything@2.0.6:
     dependencies:
@@ -11090,6 +11143,8 @@ snapshots:
       is-docker: 2.2.1
 
   isbinaryfile@4.0.10: {}
+
+  isbot@5.1.37: {}
 
   isexe@2.0.0: {}
 
@@ -12155,6 +12210,12 @@ snapshots:
 
   semver@7.7.1: {}
 
+  seroval-plugins@1.5.2(seroval@1.5.2):
+    dependencies:
+      seroval: 1.5.2
+
+  seroval@1.5.2: {}
+
   sharp@0.33.5:
     dependencies:
       color: 4.2.3
@@ -12394,10 +12455,6 @@ snapshots:
 
   tinyspy@4.0.3: {}
 
-  tippy.js@6.3.7:
-    dependencies:
-      '@popperjs/core': 2.11.8
-
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -12521,6 +12578,10 @@ snapshots:
       picocolors: 1.1.1
 
   use-sync-external-store@1.2.2(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+
+  use-sync-external-store@1.6.0(react@18.2.0):
     dependencies:
       react: 18.2.0
 

--- a/src/areas/home/index.tsx
+++ b/src/areas/home/index.tsx
@@ -1,18 +1,14 @@
 import WorkspaceApplication from "src/components/WorkspaceApplication";
 import WorkspaceApplicationList from "src/components/WorkspaceApplicationList";
 import { workspaceApps } from "src/constants";
+import { showExtensionVersionsTab } from "src/popup";
 import localize from "src/utils/localize";
 
-interface Props {
-  openSettingsView: () => void;
-  showExtensionVersionsTab: boolean;
-}
-
-const HomeView = ({ openSettingsView, showExtensionVersionsTab }: Props) => {
+const HomeView = () => {
   return (
     <>
       <p>{localize("popupMainSectionDescription")}</p>
-      <WorkspaceApplicationList onSettingsClick={openSettingsView}>
+      <WorkspaceApplicationList>
         {workspaceApps
           .filter((app) => app.isEnabled)
           .map((app) => (

--- a/src/areas/home/index.tsx
+++ b/src/areas/home/index.tsx
@@ -1,8 +1,8 @@
 import WorkspaceApplication from "src/components/WorkspaceApplication";
 import WorkspaceApplicationList from "src/components/WorkspaceApplicationList";
 import { workspaceApps } from "src/constants";
-import localize from "src/utils/localize";
 import { showExtensionVersionsTab } from "src/utils/get-browser";
+import localize from "src/utils/localize";
 
 const HomeView = () => {
   return (

--- a/src/areas/home/index.tsx
+++ b/src/areas/home/index.tsx
@@ -22,7 +22,7 @@ const HomeView = () => {
             />
           ))}
       </WorkspaceApplicationList>
-      {showExtensionVersionsTab && (
+      {showExtensionVersionsTab() && (
         <p>
           <a
             href="#"

--- a/src/areas/home/index.tsx
+++ b/src/areas/home/index.tsx
@@ -1,8 +1,8 @@
 import WorkspaceApplication from "src/components/WorkspaceApplication";
 import WorkspaceApplicationList from "src/components/WorkspaceApplicationList";
 import { workspaceApps } from "src/constants";
-import { showExtensionVersionsTab } from "src/popup";
 import localize from "src/utils/localize";
+import { showExtensionVersionsTab } from "src/utils/get-browser";
 
 const HomeView = () => {
   return (

--- a/src/areas/settings/index.tsx
+++ b/src/areas/settings/index.tsx
@@ -8,10 +8,6 @@ import localize from "src/utils/localize";
 import { createSentryClient } from "src/utils/sentry/base";
 import { SCHEMA_VERSION_KEY } from "src/utils/storage-migration";
 
-interface Props {
-  onHomeClick: () => void;
-}
-
 const DEFAULT_APP_STATE: AppStorageState = {
   zoomValue: "100%",
   viewOnly: false,
@@ -20,7 +16,7 @@ const DEFAULT_APP_STATE: AppStorageState = {
 
 const sentryScope = createSentryClient("popup");
 
-const SettingsView = ({ onHomeClick }: Props) => {
+const SettingsView = () => {
   const storage = new Storage();
   const [schemaVersion] = useStorage<number>(SCHEMA_VERSION_KEY, 1);
   const storageKeys: StorageKey[] = ["docs", "sheets"];
@@ -89,16 +85,10 @@ const SettingsView = ({ onHomeClick }: Props) => {
       <section>
         <h3>{localize("popupSettingsResetToFactoryTitle")}</h3>
         <p>{localize("popupSettingsResetToFactoryDescription")}</p>
-        <Button variant="danger" onPress={onResetZoomSettingsClick}>
+        <Button variant="danger" onPress={onResetZoomSettingsClick} isDisabled={!isExitEnabled}>
           {localize("popupSettingsResetToFactoryAction")}
         </Button>
       </section>
-      <br />
-      <hr />
-      <br />
-      <Button variant="primary" onPress={onHomeClick} isDisabled={!isExitEnabled}>
-        {localize("popupSettingsExit")}
-      </Button>
 
       {process.env.NODE_ENV === "development" && (
         <>
@@ -110,7 +100,7 @@ const SettingsView = ({ onHomeClick }: Props) => {
             <p>
               Downgrade storage schema to V1 format (flat keys) and reload to test auto-migration.
             </p>
-            <Button variant="danger" onPress={onDowngradeToV1Click}>
+            <Button variant="danger" onPress={onDowngradeToV1Click} isDisabled={!isExitEnabled}>
               Downgrade to V1 Format
             </Button>
           </section>

--- a/src/areas/settings/index.tsx
+++ b/src/areas/settings/index.tsx
@@ -20,10 +20,10 @@ const SettingsView = () => {
   const storage = new Storage();
   const [schemaVersion] = useStorage<number>(SCHEMA_VERSION_KEY, 1);
   const storageKeys: StorageKey[] = ["docs", "sheets"];
-  const [isExitEnabled, setIsExitEnabled] = useState(true);
+  const [isBusy, setIsBusy] = useState(false);
 
   const onResetZoomSettingsClick = async () => {
-    setIsExitEnabled(false);
+    setIsBusy(true);
     const resetPromises = storageKeys.map((key) => storage.set(key, { ...DEFAULT_APP_STATE }));
 
     try {
@@ -32,12 +32,12 @@ const SettingsView = () => {
       sentryScope.captureException(error);
       console.error("Failed to reset storage", error);
     } finally {
-      setIsExitEnabled(true);
+      setIsBusy(false);
     }
   };
 
   const onDowngradeToV1Click = async () => {
-    setIsExitEnabled(false);
+    setIsBusy(true);
 
     try {
       // Read current V2 state before deleting
@@ -71,7 +71,7 @@ const SettingsView = () => {
         "Failed to downgrade to V1 flat keys. Storage may be partially updated; please retry or inspect extension storage before continuing."
       );
     } finally {
-      setIsExitEnabled(true);
+      setIsBusy(false);
     }
   };
 
@@ -85,7 +85,7 @@ const SettingsView = () => {
       <section>
         <h3>{localize("popupSettingsResetToFactoryTitle")}</h3>
         <p>{localize("popupSettingsResetToFactoryDescription")}</p>
-        <Button variant="danger" onPress={onResetZoomSettingsClick} isDisabled={!isExitEnabled}>
+        <Button variant="danger" onPress={onResetZoomSettingsClick} isDisabled={isBusy}>
           {localize("popupSettingsResetToFactoryAction")}
         </Button>
       </section>
@@ -100,7 +100,7 @@ const SettingsView = () => {
             <p>
               Downgrade storage schema to V1 format (flat keys) and reload to test auto-migration.
             </p>
-            <Button variant="danger" onPress={onDowngradeToV1Click} isDisabled={!isExitEnabled}>
+            <Button variant="danger" onPress={onDowngradeToV1Click} isDisabled={isBusy}>
               Downgrade to V1 Format
             </Button>
           </section>

--- a/src/areas/settings/index.tsx
+++ b/src/areas/settings/index.tsx
@@ -1,6 +1,6 @@
 import { Storage } from "@plasmohq/storage";
 import { useStorage } from "@plasmohq/storage/hook";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import SettingsIcon from "react:~/assets/popup_icons/settings-inverted.svg";
 import Button from "src/components/Button";
 import type { AppStorageState, StorageKey } from "src/types";
@@ -21,6 +21,13 @@ const SettingsView = () => {
   const [schemaVersion] = useStorage<number>(SCHEMA_VERSION_KEY, 1);
   const storageKeys: StorageKey[] = ["docs", "sheets"];
   const [isBusy, setIsBusy] = useState(false);
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   const onResetZoomSettingsClick = async () => {
     setIsBusy(true);
@@ -32,7 +39,9 @@ const SettingsView = () => {
       sentryScope.captureException(error);
       console.error("Failed to reset storage", error);
     } finally {
-      setIsBusy(false);
+      if (isMounted.current) {
+        setIsBusy(false);
+      }
     }
   };
 
@@ -71,7 +80,9 @@ const SettingsView = () => {
         "Failed to downgrade to V1 flat keys. Storage may be partially updated; please retry or inspect extension storage before continuing."
       );
     } finally {
-      setIsBusy(false);
+      if (isMounted.current) {
+        setIsBusy(false);
+      }
     }
   };
 

--- a/src/components/WorkspaceApplicationList/index.tsx
+++ b/src/components/WorkspaceApplicationList/index.tsx
@@ -1,34 +1,17 @@
-import Tippy from "@tippyjs/react";
-import React, { type MouseEventHandler } from "react";
-import SettingsIcon from "react:~/assets/popup_icons/settings.svg";
+import React from "react";
 import localize from "src/utils/localize";
 
 import * as style from "src/style.module.css";
 
 interface Props {
   children: React.ReactNode;
-  onSettingsClick: MouseEventHandler<HTMLButtonElement>;
 }
 
-const iconHeight = 15;
-
-const WorkspaceApplicationList = ({ children, onSettingsClick }: Props) => {
+const WorkspaceApplicationList = ({ children }: Props) => {
   return (
     <>
       <h3 style={{ marginBottom: 0, display: "flex", alignItems: "center" }}>
         {localize("popupApplicationsSectionTitle")}
-        <Tippy placement="right" content={localize("popupSettingsTitle")}>
-          <button
-            onClick={onSettingsClick}
-            style={{
-              all: "unset",
-              cursor: "pointer",
-              marginLeft: 3,
-              height: iconHeight
-            }}>
-            <SettingsIcon width={iconHeight} height={iconHeight} />
-          </button>
-        </Tippy>
       </h3>
       <ul className={style.applicationList}>{children}</ul>
     </>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,6 +1,5 @@
 // Icon used in Favicon was created by https://www.flaticon.com/authors/royyan-wijaya
 import { RouterProvider } from "@tanstack/react-router";
-import { isChrome, isEdge } from "src/utils/get-browser";
 import localize from "src/utils/localize";
 import { setupSentryReactErrorBoundary } from "src/utils/sentry/react-error-boundary";
 
@@ -10,7 +9,6 @@ import { LoggerProvider } from "./utils/logger/context";
 import * as styles from "src/style.module.css";
 
 const withSentryErrorBoundary = setupSentryReactErrorBoundary("popup");
-export const showExtensionVersionsTab = isChrome() || isEdge(); // Export for HomeView
 
 // "extensionName"/"extensionNameExtended" WILL BE CHANGED. DON'T CHANGE WITHOUT MAKING OTHER CHANGES
 const extensionName = localize("extensionNameExtended");

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,47 +1,27 @@
 // Icon used in Favicon was created by https://www.flaticon.com/authors/royyan-wijaya
-import { useState } from "react";
-import HomeView from "src/areas/home";
-import SettingsView from "src/areas/settings";
-import type { CurrentView } from "src/types";
+import { RouterProvider } from "@tanstack/react-router";
 import { isChrome, isEdge } from "src/utils/get-browser";
 import localize from "src/utils/localize";
 import { setupSentryReactErrorBoundary } from "src/utils/sentry/react-error-boundary";
 
+import { router } from "./router";
 import { LoggerProvider } from "./utils/logger/context";
 
 import * as styles from "src/style.module.css";
 
 const withSentryErrorBoundary = setupSentryReactErrorBoundary("popup");
-const showExtensionVersionsTab = isChrome() || isEdge();
+export const showExtensionVersionsTab = isChrome() || isEdge(); // Export for HomeView
 
 // "extensionName"/"extensionNameExtended" WILL BE CHANGED. DON'T CHANGE WITHOUT MAKING OTHER CHANGES
 const extensionName = localize("extensionNameExtended");
 
 function IndexPopup() {
-  const [currentView, setCurrentView] = useState<CurrentView>("home");
-
-  const isSettingsView = currentView === "settings";
-  const isHomeView = currentView === "home";
-
-  const openSettingsView = () => {
-    setCurrentView("settings");
-  };
-
-  const openHomeView = () => {
-    setCurrentView("home");
-  };
-
   return (
     <LoggerProvider>
       <div className={styles.popupContainer}>
         <h1>{extensionName}</h1>
-        {isHomeView ? (
-          <HomeView
-            openSettingsView={openSettingsView}
-            showExtensionVersionsTab={showExtensionVersionsTab}
-          />
-        ) : null}
-        {isSettingsView ? <SettingsView onHomeClick={openHomeView} /> : null}
+
+        <RouterProvider router={router} />
 
         <p className={styles.supportMeLinkContainer}>
           <small>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,0 +1,65 @@
+import {
+  Link,
+  Outlet,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter
+} from "@tanstack/react-router";
+
+import HomeView from "./areas/home";
+import SettingsView from "./areas/settings";
+import localize from "./utils/localize";
+
+import * as styles from "./style.module.css";
+
+const rootRoute = createRootRoute({
+  component: () => (
+    <>
+      <nav className={styles.tabContainer}>
+        <Link
+          to="/"
+          className={styles.tabItem}
+          activeProps={{ className: `${styles.tabItem} ${styles.tabItemActive}` }}>
+          {localize("popupNavHome")}
+        </Link>
+        <Link
+          to="/settings"
+          className={styles.tabItem}
+          activeProps={{ className: `${styles.tabItem} ${styles.tabItemActive}` }}>
+          {localize("popupNavSettings")}
+        </Link>
+      </nav>
+      <Outlet />
+    </>
+  )
+});
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: HomeView
+});
+
+const settingsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/settings",
+  component: SettingsView
+});
+
+const routeTree = rootRoute.addChildren([indexRoute, settingsRoute]);
+
+const memoryHistory = createMemoryHistory({
+  initialEntries: ["/"]
+});
+
+export const router = createRouter({
+  routeTree,
+  history: memoryHistory
+});
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -20,6 +20,7 @@ const rootRoute = createRootRoute({
         <Link
           to="/"
           className={styles.tabItem}
+          activeOptions={{ exact: true }}
           activeProps={{ className: `${styles.tabItem} ${styles.tabItemActive}` }}>
           {localize("popupNavHome")}
         </Link>

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -1,5 +1,4 @@
 @import "./styles/theme.css";
-@import "tippy.js/dist/tippy.css";
 
 :root {
   --application-icon-dimension: 25px;
@@ -111,4 +110,26 @@
 
 .supportMeLinkContainer {
   text-align: center;
+}
+
+.tabContainer {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 5px;
+}
+
+.tabItem {
+  text-decoration: none;
+  color: #666;
+  font-weight: bold;
+  font-size: 0.9rem;
+  padding: 5px 10px;
+  border-radius: 5px 5px 0 0;
+}
+
+.tabItemActive {
+  color: #000;
+  border-bottom: 2px solid #3f7e9b;
 }

--- a/src/utils/get-browser.test.ts
+++ b/src/utils/get-browser.test.ts
@@ -1,18 +1,18 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
-
-import { isChrome, isEdge, isFirefox } from "./get-browser";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 describe("isChrome", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  test("should return true when chrome", () => {
+  test("should return true when chrome", async () => {
+    const { isChrome } = await import("./get-browser");
     vi.stubEnv("PLASMO_BROWSER", "chrome");
     expect(isChrome()).toBe(true);
   });
 
-  test("should return false when not chrome", () => {
+  test("should return false when not chrome", async () => {
+    const { isChrome } = await import("./get-browser");
     vi.stubEnv("PLASMO_BROWSER", "firefox");
     expect(isChrome()).toBe(false);
   });
@@ -23,12 +23,14 @@ describe("isFirefox", () => {
     vi.unstubAllEnvs();
   });
 
-  test("should return true when firefox", () => {
+  test("should return true when firefox", async () => {
+    const { isFirefox } = await import("./get-browser");
     vi.stubEnv("PLASMO_BROWSER", "firefox");
     expect(isFirefox()).toBe(true);
   });
 
-  test("should return false when not firefox", () => {
+  test("should return false when not firefox", async () => {
+    const { isFirefox } = await import("./get-browser");
     vi.stubEnv("PLASMO_BROWSER", "chrome");
     expect(isFirefox()).toBe(false);
   });
@@ -39,13 +41,43 @@ describe("isEdge", () => {
     vi.unstubAllEnvs();
   });
 
-  test("should return true when edge", () => {
+  test("should return true when edge", async () => {
+    const { isEdge } = await import("./get-browser");
     vi.stubEnv("PLASMO_BROWSER", "edge");
     expect(isEdge()).toBe(true);
   });
 
-  test("should return false when not edge", () => {
+  test("should return false when not edge", async () => {
+    const { isEdge } = await import("./get-browser");
     vi.stubEnv("PLASMO_BROWSER", "firefox");
     expect(isEdge()).toBe(false);
+  });
+});
+
+describe("showExtensionVersionsTab", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("should be true when chrome", async () => {
+    vi.stubEnv("PLASMO_BROWSER", "chrome");
+    const { showExtensionVersionsTab } = await import("./get-browser");
+    expect(showExtensionVersionsTab).toBe(true);
+  });
+
+  test("should be true when edge", async () => {
+    vi.stubEnv("PLASMO_BROWSER", "edge");
+    const { showExtensionVersionsTab } = await import("./get-browser");
+    expect(showExtensionVersionsTab).toBe(true);
+  });
+
+  test("should be false when firefox", async () => {
+    vi.stubEnv("PLASMO_BROWSER", "firefox");
+    const { showExtensionVersionsTab } = await import("./get-browser");
+    expect(showExtensionVersionsTab).toBe(false);
   });
 });

--- a/src/utils/get-browser.test.ts
+++ b/src/utils/get-browser.test.ts
@@ -1,18 +1,18 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { isChrome, isEdge, isFirefox, showExtensionVersionsTab } from "./get-browser";
 
 describe("isChrome", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  test("should return true when chrome", async () => {
-    const { isChrome } = await import("./get-browser");
+  test("should return true when chrome", () => {
     vi.stubEnv("PLASMO_BROWSER", "chrome");
     expect(isChrome()).toBe(true);
   });
 
-  test("should return false when not chrome", async () => {
-    const { isChrome } = await import("./get-browser");
+  test("should return false when not chrome", () => {
     vi.stubEnv("PLASMO_BROWSER", "firefox");
     expect(isChrome()).toBe(false);
   });
@@ -23,14 +23,12 @@ describe("isFirefox", () => {
     vi.unstubAllEnvs();
   });
 
-  test("should return true when firefox", async () => {
-    const { isFirefox } = await import("./get-browser");
+  test("should return true when firefox", () => {
     vi.stubEnv("PLASMO_BROWSER", "firefox");
     expect(isFirefox()).toBe(true);
   });
 
-  test("should return false when not firefox", async () => {
-    const { isFirefox } = await import("./get-browser");
+  test("should return false when not firefox", () => {
     vi.stubEnv("PLASMO_BROWSER", "chrome");
     expect(isFirefox()).toBe(false);
   });
@@ -41,43 +39,34 @@ describe("isEdge", () => {
     vi.unstubAllEnvs();
   });
 
-  test("should return true when edge", async () => {
-    const { isEdge } = await import("./get-browser");
+  test("should return true when edge", () => {
     vi.stubEnv("PLASMO_BROWSER", "edge");
     expect(isEdge()).toBe(true);
   });
 
-  test("should return false when not edge", async () => {
-    const { isEdge } = await import("./get-browser");
+  test("should return false when not edge", () => {
     vi.stubEnv("PLASMO_BROWSER", "firefox");
     expect(isEdge()).toBe(false);
   });
 });
 
 describe("showExtensionVersionsTab", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
-
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  test("should be true when chrome", async () => {
+  test("should be true when chrome", () => {
     vi.stubEnv("PLASMO_BROWSER", "chrome");
-    const { showExtensionVersionsTab } = await import("./get-browser");
-    expect(showExtensionVersionsTab).toBe(true);
+    expect(showExtensionVersionsTab()).toBe(true);
   });
 
-  test("should be true when edge", async () => {
+  test("should be true when edge", () => {
     vi.stubEnv("PLASMO_BROWSER", "edge");
-    const { showExtensionVersionsTab } = await import("./get-browser");
-    expect(showExtensionVersionsTab).toBe(true);
+    expect(showExtensionVersionsTab()).toBe(true);
   });
 
-  test("should be false when firefox", async () => {
+  test("should be false when firefox", () => {
     vi.stubEnv("PLASMO_BROWSER", "firefox");
-    const { showExtensionVersionsTab } = await import("./get-browser");
-    expect(showExtensionVersionsTab).toBe(false);
+    expect(showExtensionVersionsTab()).toBe(false);
   });
 });

--- a/src/utils/get-browser.ts
+++ b/src/utils/get-browser.ts
@@ -9,3 +9,5 @@ export const isFirefox = () => {
 export const isEdge = () => {
   return process.env.PLASMO_BROWSER === "edge";
 };
+
+export const showExtensionVersionsTab = isChrome() || isEdge();

--- a/src/utils/get-browser.ts
+++ b/src/utils/get-browser.ts
@@ -10,4 +10,6 @@ export const isEdge = () => {
   return process.env.PLASMO_BROWSER === "edge";
 };
 
-export const showExtensionVersionsTab = isChrome() || isEdge();
+export const showExtensionVersionsTab = () => {
+  return isChrome() || isEdge();
+};


### PR DESCRIPTION
This PR introduces TanStack Router to manage navigation within the extension popup, replacing the previous state-based view switching.

### Key Changes:
- **TanStack Router Integration**: Replaced manual `useState` view management with `@tanstack/react-router` using memory history.
- **Tab-based UI**: Implemented a persistent navigation bar at the top with 'Home' and 'Settings' tabs.
- **Dependency Cleanup**: Removed `tippy.js` and `@tippyjs/react` as they are no longer required for the UI.
- **Refactored Views**: Simplified `HomeView` and `SettingsView` by removing redundant navigation props and logic.
- **Reactivity Maintained**: Continued using Plasmo's `useStorage` hook for data fetching to ensure real-time synchronization with Chrome Storage.

Please review for architectural consistency and UI polish.