### PR TITLE
refactor: migrate from TanStack Router to React Router DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "@plasmohq/storage": "^1.15.0",
     "@sentry/browser": "^9.40.0",
     "@sentry/react": "^9.40.0",
-    "@tanstack/react-router": "^1.168.10",
     "classnames": "^2.5.1",
     "plasmo": "0.90.5",
     "react": "18.2.0",
     "react-aria-components": "^1.6.0",
     "react-dom": "18.2.0",
     "react-hot-toast": "^2.6.0",
+    "react-router-dom": "^7.14.1",
     "tslog": "^4.9.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@sentry/react':
         specifier: ^9.40.0
         version: 9.40.0(react@18.2.0)
-      '@tanstack/react-router':
-        specifier: ^1.168.10
-        version: 1.168.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -47,6 +44,9 @@ importers:
       react-hot-toast:
         specifier: ^2.6.0
         version: 2.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-router-dom:
+        specifier: ^7.14.1
+        version: 7.14.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tslog:
         specifier: ^4.9.3
         version: 4.9.3
@@ -3361,31 +3361,6 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@tanstack/history@1.161.6':
-    resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
-    engines: {node: '>=20.19'}
-
-  '@tanstack/react-router@1.168.10':
-    resolution: {integrity: sha512-/RmDlOwDkCug609KdPB3U+U1zmrtadJpvsmRg2zEn8TRCKRNri7dYZIjQZbNg8PgUiRL4T6njrZBV1ChzblNaA==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      react: '>=18.0.0 || >=19.0.0'
-      react-dom: '>=18.0.0 || >=19.0.0'
-
-  '@tanstack/react-store@0.9.3':
-    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/router-core@1.168.9':
-    resolution: {integrity: sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g==}
-    engines: {node: '>=20.19'}
-    hasBin: true
-
-  '@tanstack/store@0.9.3':
-    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
-
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
@@ -3903,8 +3878,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie-es@2.0.1:
-    resolution: {integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==}
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   copy-anything@2.0.6:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
@@ -4649,10 +4625,6 @@ packages:
   isbinaryfile@4.0.10:
     resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
     engines: {node: '>= 8.0.0'}
-
-  isbot@5.1.37:
-    resolution: {integrity: sha512-5bcicX81xf6NlTEV8rWdg7Pk01LFizDetuYGHx6d/f6y3lR2/oo8IfxjzJqn1UdDEyCcwT9e7NRloj8DwCYujQ==}
-    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -5438,6 +5410,23 @@ packages:
     resolution: {integrity: sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.14.1:
+    resolution: {integrity: sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.14.1:
+    resolution: {integrity: sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-stately@3.35.0:
     resolution: {integrity: sha512-1BH21J/TOHpyZe7c+f1BU2bnRWaBDTjLH0WdBuzNfPOXu7RBG3ebPIRvqd7UkPaVfIcol2QJnxe8S0a314JWKA==}
     peerDependencies:
@@ -5580,15 +5569,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  seroval-plugins@1.5.2:
-    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: ^1.0
-
-  seroval@1.5.2:
-    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
-    engines: {node: '>=10'}
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -5972,11 +5954,6 @@ packages:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -9937,33 +9914,6 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tanstack/history@1.161.6': {}
-
-  '@tanstack/react-router@1.168.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@tanstack/history': 1.161.6
-      '@tanstack/react-store': 0.9.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@tanstack/router-core': 1.168.9
-      isbot: 5.1.37
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-
-  '@tanstack/react-store@0.9.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@tanstack/store': 0.9.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      use-sync-external-store: 1.6.0(react@18.2.0)
-
-  '@tanstack/router-core@1.168.9':
-    dependencies:
-      '@tanstack/history': 1.161.6
-      cookie-es: 2.0.1
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
-
-  '@tanstack/store@0.9.3': {}
-
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -10527,7 +10477,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie-es@2.0.1: {}
+  cookie@1.1.1: {}
 
   copy-anything@2.0.6:
     dependencies:
@@ -11315,8 +11265,6 @@ snapshots:
       is-docker: 2.2.1
 
   isbinaryfile@4.0.10: {}
-
-  isbot@5.1.37: {}
 
   isexe@2.0.0: {}
 
@@ -12231,6 +12179,20 @@ snapshots:
 
   react-refresh@0.9.0: {}
 
+  react-router-dom@7.14.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-router: 7.14.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+
+  react-router@7.14.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      cookie: 1.1.1
+      react: 18.2.0
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 18.2.0(react@18.2.0)
+
   react-stately@3.35.0(react@18.2.0):
     dependencies:
       '@react-stately/calendar': 3.7.0(react@18.2.0)
@@ -12429,11 +12391,7 @@ snapshots:
 
   semver@7.7.1: {}
 
-  seroval-plugins@1.5.2(seroval@1.5.2):
-    dependencies:
-      seroval: 1.5.2
-
-  seroval@1.5.2: {}
+  set-cookie-parser@2.7.2: {}
 
   sharp@0.33.5:
     dependencies:
@@ -12820,10 +12778,6 @@ snapshots:
       picocolors: 1.1.1
 
   use-sync-external-store@1.2.2(react@18.2.0):
-    dependencies:
-      react: 18.2.0
-
-  use-sync-external-store@1.6.0(react@18.2.0):
     dependencies:
       react: 18.2.0
 

--- a/src/areas/settings/index.tsx
+++ b/src/areas/settings/index.tsx
@@ -1,7 +1,7 @@
 import { Storage } from "@plasmohq/storage";
 import { useStorage } from "@plasmohq/storage/hook";
-import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import SettingsIcon from "react:~/assets/popup_icons/settings-inverted.svg";
 import Button from "src/components/Button";
 import type { AppStorageState, StorageKey } from "src/types";
@@ -87,11 +87,9 @@ const SettingsView = () => {
       }
     }
   };
-
   const onExitSettingsClick = () => {
-    navigate({ to: "/" });
+    navigate("/");
   };
-
   return (
     <div>
       <h2 style={{ display: "flex", alignItems: "center" }}>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,3 +1,5 @@
+// Icon used in Favicon was created by https://www.flaticon.com/authors/royyan-wijaya
+
 import "@picocss/pico/css/pico.min.css";
 import localize from "src/utils/localize";
 import { setupSentryReactErrorBoundary } from "src/utils/sentry/react-error-boundary";

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,11 +1,8 @@
-// Icon used in Favicon was created by https://www.flaticon.com/authors/royyan-wijaya
-import { RouterProvider } from "@tanstack/react-router";
-
 import "@picocss/pico/css/pico.min.css";
 import localize from "src/utils/localize";
 import { setupSentryReactErrorBoundary } from "src/utils/sentry/react-error-boundary";
 
-import { router } from "./router";
+import { AppRouter } from "./router";
 import { LoggerProvider } from "./utils/logger/context";
 
 import * as styles from "src/style.module.css";
@@ -21,7 +18,7 @@ export function IndexPopup() {
       <main className={`container ${styles.popupContainer}`}>
         <h1>{extensionName}</h1>
 
-        <RouterProvider router={router} />
+        <AppRouter />
 
         <p className={styles.supportMeLinkContainer}>
           <small>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,11 +1,4 @@
-import {
-  Link,
-  Outlet,
-  createMemoryHistory,
-  createRootRoute,
-  createRoute,
-  createRouter
-} from "@tanstack/react-router";
+import { MemoryRouter, NavLink, Route, Routes } from "react-router-dom";
 
 import HomeView from "./areas/home";
 import SettingsView from "./areas/settings";
@@ -13,60 +6,36 @@ import localize from "./utils/localize";
 
 import * as styles from "./style.module.css";
 
-const rootRoute = createRootRoute({
-  component: () => (
-    <>
+export function AppRouter() {
+  return (
+    <MemoryRouter>
       <nav className={styles.navTabs}>
         <ul>
           <li>
-            <Link
+            <NavLink
               to="/"
-              className={styles.tabLink}
-              activeOptions={{ exact: true }}
-              activeProps={{ className: `${styles.tabLink} ${styles.tabLinkActive}` }}>
+              className={({ isActive }) =>
+                isActive ? `${styles.tabLink} ${styles.tabLinkActive}` : styles.tabLink
+              }
+              end>
               {localize("popupNavHome")}
-            </Link>
+            </NavLink>
           </li>
           <li>
-            <Link
+            <NavLink
               to="/settings"
-              className={styles.tabLink}
-              activeProps={{ className: `${styles.tabLink} ${styles.tabLinkActive}` }}>
+              className={({ isActive }) =>
+                isActive ? `${styles.tabLink} ${styles.tabLinkActive}` : styles.tabLink
+              }>
               {localize("popupNavSettings")}
-            </Link>
+            </NavLink>
           </li>
         </ul>
       </nav>
-      <Outlet />
-    </>
-  )
-});
-
-const indexRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/",
-  component: HomeView
-});
-
-const settingsRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/settings",
-  component: SettingsView
-});
-
-const routeTree = rootRoute.addChildren([indexRoute, settingsRoute]);
-
-const memoryHistory = createMemoryHistory({
-  initialEntries: ["/"]
-});
-
-export const router = createRouter({
-  routeTree,
-  history: memoryHistory
-});
-
-declare module "@tanstack/react-router" {
-  interface Register {
-    router: typeof router;
-  }
+      <Routes>
+        <Route path="/" element={<HomeView />} />
+        <Route path="/settings" element={<SettingsView />} />
+      </Routes>
+    </MemoryRouter>
+  );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "extends": "plasmo/templates/tsconfig.base",
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "vite.config.ts"],
   "include": [".plasmo/index.d.ts", ".plasmo/messaging.d.ts", "./**/*.ts", "./**/*.tsx"],
   "compilerOptions": {
     "paths": {
       //      "~*": ["./src/*"]
     },
     "baseUrl": ".",
+    "strictNullChecks": true,
     "jsx": "react-jsx",
     "types": ["vite-plugin-svgr/client", "chrome"]
   },


### PR DESCRIPTION
This pull request migrates the extension's routing logic from @tanstack/react-router to react-router-dom. 

Key changes include:
- Replaced @tanstack/react-router with react-router-dom in package.json.
- Refactored src/router.tsx to use MemoryRouter, Routes, and Route.
- Updated src/popup.tsx to use the new AppRouter component.
- Updated useNavigate usage in src/areas/settings/index.tsx.
- Enabled strictNullChecks in tsconfig.json and excluded vite.config.ts from compilation.